### PR TITLE
feat: add reading room endpoint

### DIFF
--- a/src/app/hyuabot/api/api/api_v1/__init__.py
+++ b/src/app/hyuabot/api/api/api_v1/__init__.py
@@ -1,3 +1,5 @@
 from app.hyuabot.api.api.api_v1.api import shuttle_router, bus_router
+from app.hyuabot.api.api.api_v1.endpoints.reading_room.campus import reading_room_router
 
-API_V1_ROUTERS = [shuttle_router, bus_router]
+
+API_V1_ROUTERS = [shuttle_router, bus_router, reading_room_router]

--- a/src/app/hyuabot/api/api/api_v1/api.py
+++ b/src/app/hyuabot/api/api/api_v1/api.py
@@ -1,6 +1,5 @@
 from fastapi import APIRouter
 
-
 from app.hyuabot.api.api.api_v1.endpoints.shuttle import route as shuttle_route, \
                                                             stop as shuttle_stop, \
                                                             location as shuttle_location, \

--- a/src/app/hyuabot/api/api/api_v1/endpoints/reading_room/__init__.py
+++ b/src/app/hyuabot/api/api/api_v1/endpoints/reading_room/__init__.py
@@ -1,0 +1,5 @@
+# Query params
+from fastapi import Query
+
+campus_query = Query(None, alias="campus", description="캠퍼스 ID(seoul/erica)",
+                           regex="^(seoul|erica)$", example="seoul")

--- a/src/app/hyuabot/api/api/api_v1/endpoints/reading_room/campus.py
+++ b/src/app/hyuabot/api/api/api_v1/endpoints/reading_room/campus.py
@@ -1,0 +1,19 @@
+import json
+
+from fastapi import APIRouter
+
+from app.hyuabot.api.api.api_v1.endpoints.reading_room import campus_query
+from app.hyuabot.api.core.database import get_redis_connection, get_redis_value
+from app.hyuabot.api.schemas.reading_room import ReadingRoomItem
+
+
+reading_room_router = APIRouter(prefix="/library")
+
+
+@reading_room_router.get("", status_code=200, response_model=list[ReadingRoomItem])
+async def fetch_reading_room_by_campus(campus_name: str = campus_query):
+    redis_connection = await get_redis_connection("reading_room")
+    key = f"{campus_name.lower()}_reading_room"
+    json_string: bytes = await get_redis_value(redis_connection, key)
+    reading_room_list: list[ReadingRoomItem] = json.loads(json_string.decode("utf-8"))
+    return reading_room_list

--- a/src/app/hyuabot/api/api/api_v1/endpoints/reading_room/campus.py
+++ b/src/app/hyuabot/api/api/api_v1/endpoints/reading_room/campus.py
@@ -16,4 +16,5 @@ async def fetch_reading_room_by_campus(campus_name: str = campus_query):
     key = f"{campus_name.lower()}_reading_room"
     json_string: bytes = await get_redis_value(redis_connection, key)
     reading_room_list: list[ReadingRoomItem] = json.loads(json_string.decode("utf-8"))
+    await redis_connection.close()
     return reading_room_list

--- a/src/app/hyuabot/api/core/fetch/__init__.py
+++ b/src/app/hyuabot/api/core/fetch/__init__.py
@@ -1,3 +1,8 @@
 from fastapi import APIRouter
 
+from app.hyuabot.api.core.fetch.bus import fetch_bus_router
+from app.hyuabot.api.core.fetch.reading_room import fetch_reading_room_router
+
 fetch_router = APIRouter(prefix="/fetch")
+fetch_router.include_router(fetch_bus_router)
+fetch_router.include_router(fetch_reading_room_router)

--- a/src/app/hyuabot/api/core/fetch/bus.py
+++ b/src/app/hyuabot/api/core/fetch/bus.py
@@ -4,24 +4,15 @@ from datetime import datetime
 
 import aiohttp
 from bs4 import BeautifulSoup
+from fastapi import APIRouter
 from starlette.responses import JSONResponse
 
 from app.hyuabot.api.core.config import AppSettings
 from app.hyuabot.api.core.database import get_redis_connection, get_redis_value, set_redis_value
-from app.hyuabot.api.core.fetch import fetch_router
 
+fetch_bus_router = APIRouter(prefix="/bus")
 
-async def fetch_bus_timetable_redis(route_id: str, day_key: str) -> list:
-    redis_connection = await get_redis_connection("bus")
-
-    key = f"bus_{route_id}_{day_key}"
-    json_string: bytes = await get_redis_value(redis_connection, key)
-    timetable: list[str] = json.loads(json_string.decode("utf-8"))
-    await redis_connection.close()
-    return timetable
-
-
-@fetch_router.get("/bus", status_code=200)
+@fetch_bus_router.get("", status_code=200)
 async def fetch_bus_realtime_in_a_row() -> JSONResponse:
     bus_route_dict = {
         "10-1": ("216000068", "216000379"),
@@ -84,3 +75,12 @@ async def fetch_bus_realtime(stop_id: str, route_id: str) -> list[dict]:
             await redis_connection.close()
 
             return arrival_list
+
+async def fetch_bus_timetable_redis(route_id: str, day_key: str) -> list:
+    redis_connection = await get_redis_connection("bus")
+
+    key = f"bus_{route_id}_{day_key}"
+    json_string: bytes = await get_redis_value(redis_connection, key)
+    timetable: list[str] = json.loads(json_string.decode("utf-8"))
+    await redis_connection.close()
+    return timetable

--- a/src/app/hyuabot/api/core/fetch/bus.py
+++ b/src/app/hyuabot/api/core/fetch/bus.py
@@ -12,6 +12,7 @@ from app.hyuabot.api.core.database import get_redis_connection, get_redis_value,
 
 fetch_bus_router = APIRouter(prefix="/bus")
 
+
 @fetch_bus_router.get("", status_code=200)
 async def fetch_bus_realtime_in_a_row() -> JSONResponse:
     bus_route_dict = {
@@ -75,6 +76,7 @@ async def fetch_bus_realtime(stop_id: str, route_id: str) -> list[dict]:
             await redis_connection.close()
 
             return arrival_list
+
 
 async def fetch_bus_timetable_redis(route_id: str, day_key: str) -> list:
     redis_connection = await get_redis_connection("bus")

--- a/src/app/hyuabot/api/core/fetch/reading_room.py
+++ b/src/app/hyuabot/api/core/fetch/reading_room.py
@@ -38,10 +38,11 @@ async def fetch_reading_room_api(campus_name: str, campus_id: int) -> list[dict]
                 reading_room_item = {
                     "name": reading_room_result_item["name"],
                     "isActive": reading_room_result_item["isActive"],
-                    "totalSeat": reading_room_result_item["total"],
-                    "activeSeat": reading_room_result_item["activeTotal"],
-                    "usedSeat": reading_room_result_item["occupied"],
-                    "availableSeat": reading_room_result_item["available"],
+                    "isReservable": reading_room_result_item["isReservable"],
+                    "total": reading_room_result_item["total"],
+                    "activeTotal": reading_room_result_item["activeTotal"],
+                    "occupied": reading_room_result_item["occupied"],
+                    "available": reading_room_result_item["available"],
                 }
                 reading_room_result.append(reading_room_item)
     redis_connection = await get_redis_connection("reading_room")

--- a/src/app/hyuabot/api/core/fetch/reading_room.py
+++ b/src/app/hyuabot/api/core/fetch/reading_room.py
@@ -1,0 +1,53 @@
+import asyncio
+import json
+from datetime import datetime
+
+import aiohttp
+from fastapi import APIRouter
+from starlette.responses import JSONResponse
+
+from app.hyuabot.api.core.database import get_redis_connection, set_redis_value
+
+fetch_reading_room_router = APIRouter(prefix="/library")
+
+
+@fetch_reading_room_router.get("", status_code=200)
+async def fetch_reading_room() -> JSONResponse:
+    campus_id_dict = {
+        "seoul": 1,
+        "erica": 2,
+    }
+
+    tasks = []
+    for campus_name, campus_id in campus_id_dict.items():
+        tasks.append(fetch_reading_room_api(campus_name, campus_id))
+    await asyncio.gather(*tasks)
+    return JSONResponse({"message": "Fetch reading room data success"}, status_code=200)
+
+
+async def fetch_reading_room_api(campus_name: str, campus_id: int) -> list[dict]:
+    url = f"https://lib.hanyang.ac.kr/smufu-api/pc/{campus_id}/rooms-at-seat"
+
+    timeout = aiohttp.ClientTimeout(total=3.0)
+    reading_room_result = []
+    async with aiohttp.ClientSession(timeout=timeout) as session:
+        async with session.get(url) as response:
+            response_json = await response.json()
+            reading_room_list: list = response_json["data"]["list"]
+            for reading_room_result_item in reading_room_list:
+                reading_room_item = {
+                    "name": reading_room_result_item["name"],
+                    "isActive": reading_room_result_item["isActive"],
+                    "totalSeat": reading_room_result_item["total"],
+                    "activeSeat": reading_room_result_item["activeTotal"],
+                    "usedSeat": reading_room_result_item["occupied"],
+                    "availableSeat": reading_room_result_item["available"],
+                }
+                reading_room_result.append(reading_room_item)
+    redis_connection = await get_redis_connection("reading_room")
+    await set_redis_value(redis_connection, f"{campus_name}_reading_room",
+                          json.dumps(reading_room_result, ensure_ascii=False).encode("utf-8"))
+    await set_redis_value(redis_connection, f"{campus_name}_update_time",
+                          datetime.now().strftime("%m/%d/%Y, %H:%M:%S"))
+    await redis_connection.close()
+    return reading_room_result

--- a/src/app/hyuabot/api/core/fetch/reading_room.py
+++ b/src/app/hyuabot/api/core/fetch/reading_room.py
@@ -28,9 +28,8 @@ async def fetch_reading_room() -> JSONResponse:
 async def fetch_reading_room_api(campus_name: str, campus_id: int) -> list[dict]:
     url = f"https://lib.hanyang.ac.kr/smufu-api/pc/{campus_id}/rooms-at-seat"
 
-    timeout = aiohttp.ClientTimeout(total=3.0)
     reading_room_result = []
-    async with aiohttp.ClientSession(timeout=timeout) as session:
+    async with aiohttp.ClientSession() as session:
         async with session.get(url) as response:
             response_json = await response.json()
             reading_room_list: list = response_json["data"]["list"]

--- a/src/app/hyuabot/api/core/fetch/reading_room.py
+++ b/src/app/hyuabot/api/core/fetch/reading_room.py
@@ -9,15 +9,14 @@ from starlette.responses import JSONResponse
 from app.hyuabot.api.core.database import get_redis_connection, set_redis_value
 
 fetch_reading_room_router = APIRouter(prefix="/library")
+campus_id_dict = {
+    "seoul": 1,
+    "erica": 2,
+}
 
 
 @fetch_reading_room_router.get("", status_code=200)
 async def fetch_reading_room() -> JSONResponse:
-    campus_id_dict = {
-        "seoul": 1,
-        "erica": 2,
-    }
-
     tasks = []
     for campus_name, campus_id in campus_id_dict.items():
         tasks.append(fetch_reading_room_api(campus_name, campus_id))

--- a/src/app/hyuabot/api/initialize_data.py
+++ b/src/app/hyuabot/api/initialize_data.py
@@ -7,6 +7,7 @@ from aioredis import Redis
 
 # 초기 서버 시작 시 셔틀 버스 정보 redis 저장
 from app.hyuabot.api.core.database import get_redis_connection, set_redis_value
+from app.hyuabot.api.core.fetch.reading_room import fetch_reading_room_api
 
 
 async def load_shuttle_timetable():
@@ -122,7 +123,12 @@ async def store_subway_timetable_redis(redis_connection: Redis, url: str, key: s
 
 
 async def initialize_data():
-    await load_shuttle_timetable()
-    await store_shuttle_date_redis()
-    await load_bus_timetable()
-    await load_subway_timetable()
+    tasks = [
+        load_shuttle_timetable(),
+        store_shuttle_date_redis(),
+        load_bus_timetable(),
+        load_subway_timetable(),
+        fetch_reading_room_api("seoul", 1),
+        fetch_reading_room_api("erica", 2),
+    ]
+    await asyncio.gather(*tasks)

--- a/tests/test_reading_room_endpoint.py
+++ b/tests/test_reading_room_endpoint.py
@@ -1,0 +1,45 @@
+import pytest as pytest
+from httpx import AsyncClient
+
+
+from app.hyuabot.api.core.config import AppSettings
+from app.hyuabot.api.main import app
+
+
+campus_keys = ["seoul", "erica"]
+
+
+@pytest.mark.asyncio
+async def test_reading_room_by_campus():
+    app_settings = AppSettings()
+    for campus in campus_keys:
+        async with AsyncClient(app=app, base_url="http://127.0.0.1:8000") as client:
+            response = await client.get(f"{app_settings.API_V1_STR}/library?campus={campus}")
+            response_json = response.json()
+            print(type(response_json))
+
+            assert response.status_code == 200
+            assert type(response_json) == list
+            for reading_room_item in response_json:
+                assert "name" in reading_room_item.keys() and type(reading_room_item["name"] == str)
+                assert "isActive" in reading_room_item.keys() and \
+                       type(reading_room_item["isActive"]) == bool
+                assert "isReservable" in reading_room_item.keys() and \
+                       type(reading_room_item["isReservable"]) == bool
+                assert "total" in reading_room_item.keys() and type(reading_room_item["total"]) == int
+                assert "activeTotal" in reading_room_item.keys() and \
+                       type(reading_room_item["activeTotal"]) == int
+                assert "occupied" in reading_room_item.keys() and \
+                    type(reading_room_item["occupied"]) == int
+                assert "available" in reading_room_item.keys() and \
+                       type(reading_room_item["available"]) == int
+
+
+@pytest.mark.asyncio
+async def test_fetch_reading_room_information():
+    async with AsyncClient(app=app, base_url="http://127.0.0.1:8000") as client:
+        response = await client.get("/fetch/library")
+        response_json = response.json()
+        assert response.status_code == 200
+        assert "message" in response_json.keys()
+        assert "Fetch reading room data success" == response_json["message"]

--- a/tests/test_reading_room_endpoint.py
+++ b/tests/test_reading_room_endpoint.py
@@ -10,13 +10,22 @@ campus_keys = ["seoul", "erica"]
 
 
 @pytest.mark.asyncio
+async def test_fetch_reading_room_information():
+    async with AsyncClient(app=app, base_url="http://127.0.0.1:8000") as client:
+        response = await client.get("/fetch/library")
+        response_json = response.json()
+        assert response.status_code == 200
+        assert "message" in response_json.keys()
+        assert "Fetch reading room data success" == response_json["message"]
+
+
+@pytest.mark.asyncio
 async def test_reading_room_by_campus():
     app_settings = AppSettings()
     for campus in campus_keys:
         async with AsyncClient(app=app, base_url="http://127.0.0.1:8000") as client:
             response = await client.get(f"{app_settings.API_V1_STR}/library?campus={campus}")
             response_json = response.json()
-            print(type(response_json))
 
             assert response.status_code == 200
             assert type(response_json) == list
@@ -33,13 +42,3 @@ async def test_reading_room_by_campus():
                     type(reading_room_item["occupied"]) == int
                 assert "available" in reading_room_item.keys() and \
                        type(reading_room_item["available"]) == int
-
-
-@pytest.mark.asyncio
-async def test_fetch_reading_room_information():
-    async with AsyncClient(app=app, base_url="http://127.0.0.1:8000") as client:
-        response = await client.get("/fetch/library")
-        response_json = response.json()
-        assert response.status_code == 200
-        assert "message" in response_json.keys()
-        assert "Fetch reading room data success" == response_json["message"]


### PR DESCRIPTION
1. Reading Room List
- 모든 캠퍼스(서울/ERICA)의 실시간 열람실 정보 갱신
- Endpoint : /api/v1/library
- Query params : campus - 캠퍼스 이름 (seoul/erica 중 하나의 값을 가질 수 있음)
